### PR TITLE
Don't error when git describe returns the empty string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,7 @@ def extract_version():
                                       stderr=subprocess.DEVNULL)
             result.wait()
             git_describe_output = result.stdout.read().decode('utf-8').strip()
-            if git_describe_output != version:
+            if git_describe_output and git_describe_output != version:
                 version += " (" + git_describe_output + ")"
         except:
             # We warn about, but otherwise ignore exceptions here.


### PR DESCRIPTION
Parenthesized versions seem to not be valid anymore